### PR TITLE
Fix for reader WPS files in xls

### DIFF
--- a/src/PhpSpreadsheet/Shared/OLERead.php
+++ b/src/PhpSpreadsheet/Shared/OLERead.php
@@ -265,7 +265,7 @@ class OLERead
         $offset = 0;
 
         // loop through entires, each entry is 128 bytes
-        $entryLen = strlen($this->entry);
+        $entryLen = strlen(trim($this->entry));
         while ($offset < $entryLen) {
             // entry data (128 bytes)
             $d = substr($this->entry, $offset, self::PROPERTY_STORAGE_BLOCK_SIZE);


### PR DESCRIPTION
Fix for reader WPS files in xls. When try read xls files saved in WPS get error: Call to a member function get() on null

This is:

```
- [x ] a bugfix
- [ ] a new feature
```

Checklist:

- [ ] Changes are covered by unit tests
- [ ] Code style is respected
- [ ] Commit message explains **why** the change is made (see https://github.com/erlang/otp/wiki/Writing-good-commit-messages)
- [ ] CHANGELOG.md contains a short summary of the change
- [ ] Documentation is updated as necessary

### Why this change is needed?
